### PR TITLE
Add elapsed_time field to VisionResult message.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,6 @@
+# FIXME: Update this file to compile protos.
+# This is useful to check that protos build before sending PRs.
+
 cmake_minimum_required(VERSION 2.8)
 project(build_protos C CXX)
 

--- a/vision/vision.proto
+++ b/vision/vision.proto
@@ -170,4 +170,11 @@ message VisionResult {
   // Same as above but with a resolution that is expected to have less details,
   // i.e.: 640x480 instead of 3840x2160. It could be useful to give the client an idea
   bytes image_small = 3;
+  // Elapsed time.
+  // If a program receives a proto of type VisionResult, what should it do with the
+  // elapsed time? Increment it? Perhaps this is the best thing to do. But we ware:
+  // The meaning of the field only makes sense in the context of a specific program.
+  // Known uses:
+  // - Detection server: Time to process a request.
+  float elapsed_time = 4;
 }


### PR DESCRIPTION
Maciek: Please check. This is for the discussion we had yesterday about measuring performance. Does it make sense?

Note: I didn't check that the change compiles. We need to fix CMakeLists.txt.