### PR TITLE
Removing do_calibration from the HumidityParams msg

### DIFF
--- a/malos/driver.proto
+++ b/malos/driver.proto
@@ -167,9 +167,6 @@ message Humidity {
 message HumidityParams{
   // Current temperature used for calibration.
   float current_temperature = 1; 
-
-  // Flag that indicates that the current_temperature value is valid.
-  bool do_calibration = 2;
 }
 
 // Basic UV radiation lecture.


### PR DESCRIPTION
The do_calibration was intended to prevent using the default value of current_temperature as a valid one. But as this parameter is right know the only one been used for Humidity Driver DriverConfig message,  the do_calibration flag is no really required.