### PR TITLE
Adds video and image list fields to VisionRequest

### DIFF
--- a/vision/vision.proto
+++ b/vision/vision.proto
@@ -189,6 +189,10 @@ message Video {
 
   // Video codec used to encode data
   EnumVideoCodec codec = 2;
+
+  // Arbitrary text to tags for video content
+  // ie. tagging for training purposes
+  repeated string tag = 3;
 }
 
 // This message organizes (at least) four components:

--- a/vision/vision.proto
+++ b/vision/vision.proto
@@ -161,19 +161,18 @@ message RectangularDetection {
   bytes image_small = 7;
 }
 
-// Collection of images used as source for
-// a detection
+// Collection of images. For some applications the 
+// order can be important for others doesn't. 
 message ImageList {
-  // image data 
+  // Image data 
   repeated bytes data = 1;
 
-  // if image data above was taken in a sequence, the fps should 
-  // describe how many of such frames were taken in a second
-  int32 fps = 2;
+  // If image data above was taken in a sequence, the frame rate
+  // at which images were taken
+  int32 frames_per_second = 2;
 }
 
-// Enumeration of video codecs available for 
-// vision requests
+// Video codecs available for vision requests
 enum EnumVideoCodec {
   UNDEFINED = 0;
   H264 = 1;
@@ -183,7 +182,7 @@ enum EnumVideoCodec {
   VP9 = 5;
 }
 
-// Source video for recognitions.
+// Source video
 message Video {
   // RGB video data
   bytes data = 1;
@@ -192,7 +191,7 @@ message Video {
   EnumVideoCodec codec = 2;
 }
 
-// This proto organizes (at least) four components:
+// This message organizes (at least) four components:
 // - Detections (faces, hands, cars).
 // - Tracking information.
 // - Recognition (gender, age, emotion).

--- a/vision/vision.proto
+++ b/vision/vision.proto
@@ -150,6 +150,37 @@ message RectangularDetection {
   bytes image_small = 7;
 }
 
+// Collection of images used as source for
+// a detection
+message ImageList {
+  // image data 
+  repeated bytes data = 1;
+
+  // if image data above was taken in a sequence, the fps should 
+  // describe how many of such frames were taken in a second
+  int32 fps = 2;
+}
+
+// Enumeration of video codecs available for 
+// vision requests
+enum EnumVideoCodec {
+  UNDEFINED = 0;
+  H264 = 1;
+  MP4V = 2;
+  RV24 = 3;
+  VP8 = 4;
+  VP9 = 5;
+}
+
+// Source video for recognitions.
+message Video {
+  // RGB video data
+  bytes data = 1;
+
+  // Video codec used to encode data
+  EnumVideoCodec codec = 2;
+}
+
 // This proto organizes (at least) four components:
 // - Detections (faces, hands, cars).
 // - Tracking information.

--- a/vision/vision.proto
+++ b/vision/vision.proto
@@ -190,7 +190,7 @@ message Video {
   // Video codec used to encode data
   EnumVideoCodec codec = 2;
 
-  // Arbitrary text to tags for video content
+  // Arbitrary text to tag video content
   // ie. tagging for training purposes
   repeated string tag = 3;
 }

--- a/vision/vision_service.proto
+++ b/vision/vision_service.proto
@@ -9,8 +9,7 @@ package admobilize_vision;
 
 import "vision.proto";
 
-// This proto aims at providing a flexible structure for client applications
-// to request processing by video services.
+// Message used to send vision requests
 message VisionRequest {
   // Image for the request.
   bytes image = 1;
@@ -22,12 +21,11 @@ message VisionRequest {
   // after the detections.
   repeated EnumFacialRecognitionTag recognition = 3;
 
-  // It is sometimes more convenient to send many images to be processed
+  // It is sometimes more convenient to send more than one image to be processed
   // by vision services
   ImageList image_list = 4;
 
-  // or video data if splitting into frames is not convenient
-  // in the client.
+  // Video data 
   Video video = 5;
 }
 

--- a/vision/vision_service.proto
+++ b/vision/vision_service.proto
@@ -9,6 +9,8 @@ package admobilize_vision;
 
 import "vision.proto";
 
+// This proto aims at providing a flexible structure for client applications
+// to request processing by video services.
 message VisionRequest {
   // Image for the request.
   bytes image = 1;
@@ -19,6 +21,14 @@ message VisionRequest {
   // Recognitions to perform on the image. The recognitions should be done
   // after the detections.
   repeated EnumFacialRecognitionTag recognition = 3;
+
+  // It is sometimes more convenient to send many images to be processed
+  // by vision services
+  ImageList image_list = 4;
+
+  // or video data if splitting into frames is not convenient
+  // in the client.
+  Video video = 5;
 }
 
 service VisionService {


### PR DESCRIPTION
Adds proposal for video and image list fields that can be used for vision requests. The goal is to make `VisionRequest` a general purpose message, that we can use across different systems, the same way we are currently using `VisionResult`  messages.