### PR TITLE
Fix to protobufjs 5.1 issue

### DIFF
--- a/vision/vision.proto
+++ b/vision/vision.proto
@@ -103,7 +103,7 @@ message FacialRecognition {
   // The following fields should only be present when the tag FACE_DESCRIPTOR is set.
 
   // Face descriptor.
-  repeated float face_descriptor = 6;
+  repeated float face_descriptor = 6 [packed=true];
 
   // The following fields should only be present when the tag HAS_FACE_ID is set.
 

--- a/vision/vision.proto
+++ b/vision/vision.proto
@@ -102,7 +102,8 @@ message FacialRecognition {
 
   // The following fields should only be present when the tag FACE_DESCRIPTOR is set.
 
-  // Face descriptor.
+  // Face descriptor. Setting packed=true because of a
+  // protobufjs 5.1 bug. packed=true is the default for proto3 syntax.
   repeated float face_descriptor = 6 [packed=true];
 
   // The following fields should only be present when the tag HAS_FACE_ID is set.


### PR DESCRIPTION
For protobuf version 3, all repeated fields (for basic types)
are packed by default, so this is not really needed.
But protobufjs 5.1 fails to parse the proto if this is not set.

More info here: https://developers.google.com/protocol-buffers/docs/encoding#packed