### PR TITLE
Review of recognition protos

### DIFF
--- a/vision/recognition.proto
+++ b/vision/recognition.proto
@@ -1,0 +1,25 @@
+
+syntax = "proto3";
+
+// Describes a recognition feature descriptor
+message FeatureDescriptor {
+
+  // A unique identifier for the descriptor according to UUID v4
+  string uuid = 1; 
+
+  // Descriptor format used by extraction algorithm
+  string data_format = 2;
+
+  // The actual recognition descriptor data
+  repeated float data = 3;
+
+  // Arbitrary tags for the descriptor set
+  repeated string tags = 4;
+}
+
+// Container to group multiple FeatureDescriptors
+// makes storage of multiple FeatureDescriptors more
+// convenient
+message FeatureDescriptorList {
+   repeated FeatureDescriptor feature_descriptors = 1;
+}

--- a/vision/recognition.proto
+++ b/vision/recognition.proto
@@ -1,6 +1,8 @@
 
 syntax = "proto3";
 
+package admobilize_vision;
+
 // Describes a recognition feature descriptor
 message FeatureDescriptor {
 

--- a/vision/recognition.proto
+++ b/vision/recognition.proto
@@ -16,12 +16,14 @@ message FeatureDescriptor {
   repeated float data = 3;
 
   // Arbitrary tags for the descriptor set
+  // i.e ['lucas', 'jackson family'] 
   repeated string tags = 4;
 }
 
 // Container to group multiple FeatureDescriptors
 // makes storage of multiple FeatureDescriptors more
-// convenient
+// convenient in files.
 message FeatureDescriptorList {
+
    repeated FeatureDescriptor feature_descriptors = 1;
 }

--- a/vision/recognition_service.proto
+++ b/vision/recognition_service.proto
@@ -61,6 +61,10 @@ service RecognitionService {
   rpc DeleteFeatureDescriptors(DeleteFeatureDescriptorsRequest) 
     returns (DeleteFeatureDescriptorsResponse) {}
 
+  // Request all available descriptor tags for the user account
+  rpc GetFeatureDescriptorTags(GetFeatureDescriptorTagsRequest)
+    returns (GetFeatureDescriptorTagsResponse) {}
+
   // Request a descriptor match against recognition services.
   //
   // For recognize requests to be possible, descriptors must first be
@@ -74,10 +78,6 @@ service RecognitionService {
   //   - when video field is set, descriptors will be calculated splitting 
   //     the video into frames, descriptors calculated, and then matched.
   rpc Recognize(RecognizeRequest) returns (RecognizeResponse) {}
-
-  // Request all available descriptor tags for the user account
-  rpc GetFeatureDescriptorTags(GetFeatureDescriptorTagsRequest)
-    returns (GetFeatureDescriptorTagsResponse) {}
 }
 
 // Message used when calling StoreDescriptors()
@@ -193,10 +193,17 @@ message RecognizeResponse {
   string reason = 2;
 }
 
+// Message used when calling GetFeatureDescriptorTags()
+message GetFeatureDescriptorTagsRequest {
+
+  // Device IDs to get descriptors tags for
+  repeated string device_id = 1;
+}
+
 // Groups tags per device, so client apps can
 // pull all tags and then present which tags
 // are only registered under a specific device
-message DeviceFeatureDescriptorTags {
+message FeatureDescriptorTagsForDevice {
 
   // Available descriptor tags
   repeated string tags = 1;
@@ -205,18 +212,11 @@ message DeviceFeatureDescriptorTags {
   string device_id = 2;
 }
 
-// Message used when calling GetFeatureDescriptorTags()
-message GetFeatureDescriptorTagsRequest {
-
-  // Device IDs to get descriptors tags for
-  repeated string device_id = 1;
-}
-
 // Message returned by GetFeatureDescriptorTags()
 message GetFeatureDescriptorTagsResponse {
 
   // Device ID to get descriptors tags for
-  repeated DeviceFeatureDescriptorTags device_tags = 1;
+  repeated FeatureDescriptorTagsForDevice feature_tags_for_device = 1;
 
   // In case the request fails, this field will contain the reason
   string reason = 2;

--- a/vision/recognition_service.proto
+++ b/vision/recognition_service.proto
@@ -183,6 +183,9 @@ message FeatureDescriptorMatch {
 message RecognizeResponse {
 
   // List of matches 
-  repeated FeatureDescriptorMatch match = 1;
+  repeated FeatureDescriptorMatch matches = 1;
+
+  // In case the recognize fails, this field will contain the reason
+  string reason = 2;
 }
 

--- a/vision/recognition_service.proto
+++ b/vision/recognition_service.proto
@@ -103,9 +103,6 @@ message StoreFeatureDescriptorsResponse {
 
   // Stored descriptor IDS
   repeated string uuids = 1;
-
-  // In case store request fails, will contain the reason
-  string reason = 2;
 }
 
 // Message used when calling GetDescriptors()
@@ -132,9 +129,6 @@ message GetFeatureDescriptorsResponse {
 
   // Token use for pagination when there are too many results
   string next_page_token = 2;
-
-  // In case the request fails, this field will contain the reason
-  string reason = 3;
 }
 
 // Message used when calling DeleteFeatureDescriptors()
@@ -153,9 +147,6 @@ message DeleteFeatureDescriptorsResponse {
 
   // UUIDs of deleted descriptors
   repeated string uuids = 1;
-
-  // In case the delete fails, this field will contain the reason
-  string reason = 2;
 }
 
 // Message used when calling Recognize()
@@ -188,9 +179,6 @@ message RecognizeResponse {
 
   // List of matches 
   repeated FeatureDescriptorMatch matches = 1;
-
-  // In case the recognize fails, this field will contain the reason
-  string reason = 2;
 }
 
 // Message used when calling GetFeatureDescriptorTags()
@@ -217,9 +205,4 @@ message GetFeatureDescriptorTagsResponse {
 
   // Device ID to get descriptors tags for
   repeated FeatureDescriptorTagsForDevice feature_tags_for_device = 1;
-
-  // In case the request fails, this field will contain the reason
-  string reason = 2;
 }
-
-

--- a/vision/recognition_service.proto
+++ b/vision/recognition_service.proto
@@ -74,6 +74,10 @@ service RecognitionService {
   //   - when video field is set, descriptors will be calculated splitting 
   //     the video into frames, descriptors calculated, and then matched.
   rpc Recognize(RecognizeRequest) returns (RecognizeResponse) {}
+
+  // Request all available descriptor tags for the user account
+  rpc GetFeatureDescriptorTags(GetFeatureDescriptorTagsRequest)
+    returns (GetFeatureDescriptorTagsResponse) {}
 }
 
 // Message used when calling StoreDescriptors()
@@ -188,4 +192,34 @@ message RecognizeResponse {
   // In case the recognize fails, this field will contain the reason
   string reason = 2;
 }
+
+// Groups tags per device, so client apps can
+// pull all tags and then present which tags
+// are only registered under a specific device
+message DeviceFeatureDescriptorTags {
+
+  // Available descriptor tags
+  repeated string tags = 1;
+
+  // If set, the above tags are only available in such device id
+  string device_id = 2;
+}
+
+// Message used when calling GetFeatureDescriptorTags()
+message GetFeatureDescriptorTagsRequest {
+
+  // Device IDs to get descriptors tags for
+  repeated string device_id = 1;
+}
+
+// Message returned by GetFeatureDescriptorTags()
+message GetFeatureDescriptorTagsResponse {
+
+  // Device ID to get descriptors tags for
+  repeated DeviceFeatureDescriptorTags device_tags = 1;
+
+  // In case the request fails, this field will contain the reason
+  string reason = 2;
+}
+
 

--- a/vision/recognition_service.proto
+++ b/vision/recognition_service.proto
@@ -18,6 +18,7 @@ syntax = "proto3";
 package admobilize_vision;
 
 import "vision_service.proto";
+import "recognition.proto";
 
 service RecognitionService {
 
@@ -37,7 +38,8 @@ service RecognitionService {
   // When the save is successfull, a descriptor list with the computed
   // descriptor data and uuid is returned.
   // The message will contain an error if the descriptor can't be stored.
-  rpc StoreDescriptors(StoreDescriptorRequest) returns (StoreDescriptorResponse) {}
+  rpc StoreFeatureDescriptors(StoreFeatureDescriptorsRequest) 
+    returns (StoreFeatureDescriptorsResponse) {}
 
   // Obtain descriptors saved under a user account
   //
@@ -48,14 +50,16 @@ service RecognitionService {
   // If no uuid or devices_id are defined, all descriptors available for
   // the user account will be returned
   // An empty list will be returned if no descriptors are found
-  rpc GetDescriptors(GetDescriptorRequest) returns (GetDescriptorResponse) {}
+  rpc GetFeatureDescriptors(GetFeatureDescriptorsRequest) 
+    returns (GetFeatureDescriptorsResponse) {}
 
   // Delete descriptors saved under a user account
   //
   // Method will delete all descriptors matching provided uuids. When
   // a device_id is provided, only those associated with the device will
   // be deleted
-  rpc DeleteDescriptors(DeleteDescriptorsRequest) returns (DeleteDescriptorsResponse) {}
+  rpc DeleteFeatureDescriptors(DeleteFeatureDescriptorsRequest) 
+    returns (DeleteFeatureDescriptorsResponse) {}
 
   // Request a descriptor match against recognition services.
   //
@@ -72,30 +76,18 @@ service RecognitionService {
   rpc Recognize(RecognizeRequest) returns (RecognizeResponse) {}
 }
 
-// Describes a recognition descriptor
-message Descriptor {
-
-  // A unique identifier for the descriptor according to UUID v4
-  string uuid = 1; 
-
-  // Descriptor format used by extraction algorithm
-  string data_format = 2;
-
-  // The actual recognition descriptor data
-  repeated float descriptor_data = 3;
-}
-
 // Message used when calling StoreDescriptors()
-message StoreDescriptorRequest {
+message StoreFeatureDescriptorsRequest {
 
   // Source images / video to obtain descriptors
   VisionRequest vision_request = 1;
 
-  // Set of descriptors
-  repeated Descriptor descriptor_set = 2;
+  // Arbitrary tags to use for descriptors calculated from
+  // vision_request. Ignored when feature_descriptors are set.
+  repeated string tags = 2;
 
-  // Arbitrary user defined strings for the descriptor
-  repeated string tag = 3;
+  // Set of descriptors
+  repeated FeatureDescriptor feature_descriptors = 3;
 
   // Optional device IDs to associate the descriptor
   // with a set of devices
@@ -103,50 +95,60 @@ message StoreDescriptorRequest {
 }
 
 // Message returned by StoreDescriptors()
-message StoreDescriptorResponse {
+message StoreFeatureDescriptorsResponse {
 
-  // Stored descriptor IDs in the same order they were sent
-  repeated string uuid = 1;
+  // Stored descriptor IDS
+  repeated string uuids = 1;
 
   // In case store request fails, will contain the reason
   string reason = 2;
 }
 
 // Message used when calling GetDescriptors()
-message GetDescriptorRequest {
+message GetFeatureDescriptorsRequest {
 
-  // Specific descriptors to obtain
-  repeated string uuid = 1;
+  // Specific descriptor uuids to obtain
+  repeated string uuids = 1;
+
+  // Specific tags to obtain. Ignored when uuids is defined.
+  repeated string tags = 2;
 
   // Device ID to get descriptors for
-  string device_id = 2;
+  string device_id = 3;
 
   // Next page token when paginating
-  string next_page_token = 3;
+  string next_page_token = 4;
 }
 
-// Message returned by GetDescriptors()
-message GetDescriptorResponse {
+// Message returned by GetFeatureDescriptors()
+message GetFeatureDescriptorsResponse {
 
   // Set of descriptors
-  repeated Descriptor descriptor_set = 1;
+  FeatureDescriptorList feature_descriptor_list = 1;
 
   // Token use for pagination when there are too many results
   string next_page_token = 2;
+
+  // In case the request fails, this field will contain the reason
+  string reason = 3;
 }
 
-// Message used when calling DeleteDescriptors()
-message DeleteDescriptorsRequest {
+// Message used when calling DeleteFeatureDescriptors()
+message DeleteFeatureDescriptorsRequest {
 
   // Stored descriptor IDs to delete
-  repeated string uuid = 1;
+  repeated string uuids = 1;
+
+  // Delete descriptors by tags, delete ALL descriptors
+  // matching given tags. Ignored when uuid is set.
+  repeated string tags = 2;
 }
 
 // Message returned by DeleteDescriptors()
-message DeleteDescriptorsResponse {
+message DeleteFeatureDescriptorsResponse {
 
   // UUIDs of deleted descriptors
-  repeated string uuid = 1;
+  repeated string uuids = 1;
 
   // In case the delete fails, this field will contain the reason
   string reason = 2;
@@ -159,17 +161,17 @@ message RecognizeRequest {
   VisionRequest vision_request = 1;
 
   // Set of descriptors
-  repeated Descriptor descriptor_set = 2;
+  FeatureDescriptorList feature_descriptor_list= 2;
 
   // Signals the desired algorithm for recognitions
   string matching_algorithm_version = 3;
 }
 
 // Message describes a descriptor match
-message DescriptorMatch {
+message FeatureDescriptorMatch {
 
   // user set tags
-  repeated string tag = 1;
+  repeated string tags = 1;
 
   // Score for the match from 0 to 1. 
   // A bigger value means a closer match.
@@ -181,6 +183,6 @@ message DescriptorMatch {
 message RecognizeResponse {
 
   // List of matches 
-  repeated DescriptorMatch match = 1;
+  repeated FeatureDescriptorMatch match = 1;
 }
 

--- a/vision/recognition_service.proto
+++ b/vision/recognition_service.proto
@@ -29,54 +29,57 @@ service RecognitionService {
   //   - contain a VisionRequest with a populated ImageList field
   //   - contain a VisionRequest with a populated Video field
   //
-  // The tag is mandatory for a store call to be successful.
-  // When device_id items are specified, the descriptor will be scoped
+  // The tags field is mandatory for a store call to be successful.
+  // When device_id field is set, the descriptor will be scoped
   // to the given device IDs, meaning that only Recognize() requests from such
   // device IDs will match those descriptors.
   // 
   // Returned Message
-  // When the save is successfull, a descriptor list with the computed
-  // descriptor data and uuid is returned.
-  // The message will contain an error if the descriptor can't be stored.
+  // When the save is successful, a list of unique string UUIDs identifying
+  // the stored descriptors
   rpc StoreFeatureDescriptors(StoreFeatureDescriptorsRequest) 
     returns (StoreFeatureDescriptorsResponse) {}
 
-  // Obtain descriptors saved under a user account
+  // Obtain a list of descriptors
   //
   // Returned Message
-  // A list of descriptors according to provided uuids and device_id.
+  // A list of descriptors according to provided uuids, tags and device_id.
   // if both uuid and device_id are defined, only descriptors
-  // associated with the given device ID will be returned
-  // If no uuid or devices_id are defined, all descriptors available for
-  // the user account will be returned
+  // associated with the given device ID will be returned. The same
+  // applies for tags and device_id.
+  //
+  // If no uuid, tags or devices_id fields are defined, all available 
+  // descriptor will be returned.
+  //
   // An empty list will be returned if no descriptors are found
   rpc GetFeatureDescriptors(GetFeatureDescriptorsRequest) 
     returns (GetFeatureDescriptorsResponse) {}
 
   // Delete descriptors saved under a user account
   //
-  // Method will delete all descriptors matching provided uuids. When
-  // a device_id is provided, only those associated with the device will
-  // be deleted
+  // Method will delete all descriptors matching provided uuids or tags. 
+  // When matching tags, descriptors matching any tag will be returned.
+  //
+  // When a device_id is provided, only those associated with the device will
+  // be deleted.
   rpc DeleteFeatureDescriptors(DeleteFeatureDescriptorsRequest) 
     returns (DeleteFeatureDescriptorsResponse) {}
 
-  // Request all available descriptor tags for the user account
+  // Request a set of all available descriptor tags for the user account
+  // grouped by device id
   rpc GetFeatureDescriptorTags(GetFeatureDescriptorTagsRequest)
     returns (GetFeatureDescriptorTagsResponse) {}
 
   // Request a descriptor match against recognition services.
   //
   // For recognize requests to be possible, descriptors must first be
-  // stored (see StoreDescriptors method). 
+  // stored (see StoreFeatureDescriptors method). 
   // 
   // Recognize calls can include a variety of fields:
-  //   - when descriptor field is set, it will be used to perform the match against
-  //     existent descriptors.
-  //   - when image field is set, descriptors will first be calculated for
-  //     the images and then matched.
-  //   - when video field is set, descriptors will be calculated splitting 
-  //     the video into frames, descriptors calculated, and then matched.
+  //   - when feature_descriptor_list field is set, it will be used to perform the 
+  //     match against stored descriptors.
+  //   - when vision_request field is set, descriptors will first be calculated for
+  //     the images and then matched against stored descriptors.
   rpc Recognize(RecognizeRequest) returns (RecognizeResponse) {}
 }
 
@@ -88,6 +91,7 @@ message StoreFeatureDescriptorsRequest {
 
   // Arbitrary tags to use for descriptors calculated from
   // vision_request. Ignored when feature_descriptors are set.
+  // ie ['ruben', 'godoy family']
   repeated string tags = 2;
 
   // Set of descriptors


### PR DESCRIPTION
Improves on previous iteration of recognition services and proto messages. 

* Fixes previous cardinality issues
* It is now possible to list only tags for all descriptors
* Errors are handled via `set_code` and `set_details` on grpc context
* `Descriptor` renamed to `FeatureDescriptor` to avoid clashing with internal proto attributes

@TODO add `onOf` where applies.