### PR TITLE
Updates main namespace, fixes zwave options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,4 +3,4 @@ cmake_minimum_required(VERSION 2.8)
 # For GRPC.
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
-add_subdirectory(matrixlabs)
+add_subdirectory(matrix)

--- a/matrix/CMakeLists.txt
+++ b/matrix/CMakeLists.txt
@@ -29,17 +29,17 @@ PROTOBUF_GENERATE_GRPC_CPP(
 PROTOBUF_GENERATE_CPP(
   RECOGNITION_GRPC_PROTO_SRC 
   RECOGNITION_GRPC_PROTO_HEADER 
-  vision/v1/recognition_service.proto)
+  recognition/v1/recognition_service.proto)
 
 PROTOBUF_GENERATE_GRPC_CPP(
   RECOGNITION_GRPC_SRC 
   RECOGNITION_GRPC_HEADER 
-  vision/v1/recognition_service.proto)
+  recognition/v1/recognition_service.proto)
 
 PROTOBUF_GENERATE_CPP(
   RECOGNITION_PROTO_SRC 
   RECOGNITION_PROTO_HEADER 
-  vision/v1/recognition.proto)
+  recognition/v1/recognition.proto)
 
 # driver.proto (MALOS)
 PROTOBUF_GENERATE_CPP(

--- a/matrix/malos/v1/driver.proto
+++ b/matrix/malos/v1/driver.proto
@@ -23,7 +23,7 @@ option java_multiple_files = true;
 option java_outer_classname = "DriverProto";
 option java_package = "com.matrix.malos.v1";
 
-import "zwave_commands.proto";
+import "matrix/malos/v1/zwave_commands.proto";
 
 // configuration of drivers. Both global configuration and
 // for specific drivers.
@@ -595,13 +595,13 @@ message ZWaveMsg {
 
   // ZWave command with params
   message ZWaveCommandInfo {
-    ZWaveCmdType cmd = 1;
+    matrix.malos.v1.zwave.ZWaveCmdType cmd = 1;
     repeated string param = 2;
   } 
 
   // ZWave class with params
   message ZWaveClassInfo {
-    ZWaveClassType zwave_class = 1;
+    matrix.malos.v1.zwave.ZWaveClassType zwave_class = 1;
     repeated ZWaveCommandInfo command = 2;
   }
 
@@ -615,8 +615,8 @@ message ZWaveMsg {
 
   // ZWave command to sent
   message ZWaveCommand {
-    ZWaveClassType zwclass = 1;
-    ZWaveCmdType cmd = 2;
+    matrix.malos.v1.zwave.ZWaveClassType zwclass = 1;
+    matrix.malos.v1.zwave.ZWaveCmdType cmd = 2;
     bytes params = 3;
   }
  

--- a/matrix/malos/v1/driver.proto
+++ b/matrix/malos/v1/driver.proto
@@ -16,12 +16,12 @@
 
 syntax = "proto3";
 
-package matrixlabs.malos.v1.driver;
+package matrix.malos.v1.driver;
 
-option csharp_namespace = "Matrixlabs.Malos.Driver.V1";
+option csharp_namespace = "Matrix.Malos.Driver.V1";
 option java_multiple_files = true;
 option java_outer_classname = "DriverProto";
-option java_package = "com.matrixlabs.malos.v1";
+option java_package = "com.matrix.malos.v1";
 
 import "zwave_commands.proto";
 

--- a/matrix/malos/v1/hal.proto
+++ b/matrix/malos/v1/hal.proto
@@ -15,12 +15,12 @@
 
 syntax = "proto3";
 
-package matrixlabs.malos.v1.hal;
+package matrix.malos.v1.hal;
 
-option csharp_namespace = "Matrixlabs.Malos.Hal.V1";
+option csharp_namespace = "Matrix.Malos.Hal.V1";
 option java_multiple_files = true;
 option java_outer_classname = "HalProto";
-option java_package = "com.matrixlabs.malos.v1";
+option java_package = "com.matrix.malos.v1";
 
 // Dummy lecture.
 message Dummy {

--- a/matrix/malos/v1/zwave_commands.proto
+++ b/matrix/malos/v1/zwave_commands.proto
@@ -3,12 +3,12 @@
 
 syntax = "proto3";
 
-package matrixlabs.malos.v1.driver;
+package matrix.malos.v1.zwave;
 
-option csharp_namespace = "Matrixlabs.Malos.Driver.V1";
+option csharp_namespace = "Matrix.Malos.Zwave.V1";
 option java_multiple_files = true;
-option java_outer_classname = "DriverProto";
-option java_package = "com.matrixlabs.malos.v1";
+option java_outer_classname = "ZwaveProto";
+option java_package = "com.matrix.malos.v1";
 
 enum ZWaveClassType {
  option allow_alias = true;

--- a/matrix/recognition/v1/recognition.proto
+++ b/matrix/recognition/v1/recognition.proto
@@ -1,12 +1,12 @@
 
 syntax = "proto3";
 
-package matrixlabs.vision.v1;
+package matrix.recognition.v1;
 
-option csharp_namespace = "Matrixlabs.Vision.V1";
+option csharp_namespace = "Matrix.Recognition.V1";
 option java_multiple_files = true;
 option java_outer_classname = "RecognitionProto";
-option java_package = "com.matrixlabs.vision.v1";
+option java_package = "com.matrix.recognition.v1";
 
 // Describes a recognition feature descriptor
 message FeatureDescriptor {

--- a/matrix/recognition/v1/recognition_service.proto
+++ b/matrix/recognition/v1/recognition_service.proto
@@ -15,15 +15,15 @@
 
 syntax = "proto3";
 
-package matrixlabs.vision.v1;
+package matrix.recognition.v1;
 
-import "matrixlabs/vision/v1/vision_service.proto";
-import "matrixlabs/vision/v1/recognition.proto";
+import "matrix/vision/v1/vision_service.proto";
+import "matrix/vision/v1/recognition.proto";
 
-option csharp_namespace = "Matrixlabs.Vision.V1";
+option csharp_namespace = "Matrix.Recognition.V1";
 option java_multiple_files = true;
 option java_outer_classname = "RecognitionServiceProto";
-option java_package = "com.matrixlabs.vision.v1";
+option java_package = "com.matrix.recognition.v1";
 
 service RecognitionService {
 

--- a/matrix/recognition/v1/recognition_service.proto
+++ b/matrix/recognition/v1/recognition_service.proto
@@ -18,7 +18,7 @@ syntax = "proto3";
 package matrix.recognition.v1;
 
 import "matrix/vision/v1/vision_service.proto";
-import "matrix/vision/v1/recognition.proto";
+import "matrix/recognition/v1/recognition.proto";
 
 option csharp_namespace = "Matrix.Recognition.V1";
 option java_multiple_files = true;
@@ -92,7 +92,7 @@ service RecognitionService {
 message StoreFeatureDescriptorsRequest {
 
   // Source images / video to obtain descriptors
-  VisionRequest vision_request = 1;
+  matrix.vision.v1.VisionRequest vision_request = 1;
 
   // Arbitrary tags to use for descriptors calculated from
   // vision_request. Ignored when feature_descriptors are set.
@@ -162,7 +162,7 @@ message DeleteFeatureDescriptorsResponse {
 message RecognizeRequest {
 
   // Source for VisionRequest for recognition
-  VisionRequest vision_request = 1;
+  matrix.vision.v1.VisionRequest vision_request = 1;
 
   // Set of descriptors
   FeatureDescriptorList feature_descriptor_list= 2;

--- a/matrix/vision/v1/vision.proto
+++ b/matrix/vision/v1/vision.proto
@@ -15,12 +15,12 @@
 
 syntax = "proto3";
 
-package matrixlabs.vision.v1;
+package matrix.vision.v1;
 
-option csharp_namespace = "Matrixlabs.Vision.V1";
+option csharp_namespace = "Matrix.Vision.V1";
 option java_multiple_files = true;
 option java_outer_classname = "VisionProto";
-option java_package = "com.matrixlabs.vision.v1";
+option java_package = "com.matrix.vision.v1";
 
 // Basic point.
 message Point {

--- a/matrix/vision/v1/vision_service.proto
+++ b/matrix/vision/v1/vision_service.proto
@@ -15,14 +15,14 @@
 
 syntax = "proto3";
 
-package matrixlabs.vision.v1;
+package matrix.vision.v1;
 
-import "matrixlabs/vision/v1/vision.proto";
+import "matrix/vision/v1/vision.proto";
 
-option csharp_namespace = "Matrixlabs.Vision.V1";
+option csharp_namespace = "Matrix.Vision.V1";
 option java_multiple_files = true;
 option java_outer_classname = "VisionServiceProto";
-option java_package = "com.matrixlabs.vision.v1";
+option java_package = "com.matrix.vision.v1";
 
 // Message used to send vision requests
 message VisionRequest {


### PR DESCRIPTION
- Updates `matrixlabs` to `matrix` as requested by @brianofrokk3r 
- Separates recognition protos under `recognition/v1`
- Fixes `options` in zwave protos