### PR TITLE
added additional header path for Android (workaround)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,8 @@ set(ABSProtoFiles)
 set(ProtoHeaders)
 set(ProtoSources)
 
+include_directories(${ProtoHeaders})
+
 foreach(FNAME ${proto_files})
   # relative directory for .proto file
   get_filename_component(PROTO_PATH ${FNAME} DIRECTORY)


### PR DESCRIPTION
with `-DPROTOBUF_INCLUDE_DIR` is strange but it in cross compiling for Android not load
google include paths, for this reason in a second try I send it with ProtoHeaders directive.

note: Is transparent for other architectures